### PR TITLE
Changed the fallback-wrapper element for untyped `<p:TextRegion>` 

### DIFF
--- a/page2tei-0.xsl
+++ b/page2tei-0.xsl
@@ -319,15 +319,16 @@
       </xsl:when>
       <xsl:when test="@type = 'other'">
        <p facs="#facs_{$numCurr}_{@id}">
-        <xsl:apply-templates select="p:TextLine" />
-       </p>
-      </xsl:when>
-      <xsl:otherwise>
-       <p facs="#facs_{$numCurr}_{@id}">
-        <xsl:apply-templates select="p:TextLine" />
-       </p>
-      </xsl:otherwise>
-     </xsl:choose>
+                <xsl:apply-templates select="p:TextLine" />
+            </p>
+        </xsl:when>
+        <!-- the fallback option should be a semantically open element such as <ab> -->
+        <xsl:otherwise>
+            <ab facs="#facs_{$numCurr}_{@id}">
+                <xsl:apply-templates select="p:TextLine" />
+            </ab>
+        </xsl:otherwise>
+    </xsl:choose>
     </xsl:template>
     
     <xd:doc>


### PR DESCRIPTION
As I noted in this [issue](https://github.com/dariok/page2tei/issues/16), using `<tei:p>` as a fallback wrapping element for untyped `<p:TextRegion>`s adds semantics that aren't there in the input. I therefore changed the fallback wrapper to `<tei:ab>`.