### PR TITLE
Fix incorrect grouping when identical text nodes occur

### DIFF
--- a/combine-continued.xsl
+++ b/combine-continued.xsl
@@ -70,8 +70,11 @@
                         )[1]"
                   />
                   <xsl:try>
-                     <xsl:variable name="last" select="index-of(current-group(), $final)[1]"/>
-                     
+                     <xsl:variable name="last" select="let $group := current-group()
+                        return
+                        for $i in 1 to count($group)
+                        return
+                           if ($group[$i] is $final) then $i else ()"/>
                   <xsl:element name="{local-name()}">
                      <xsl:apply-templates select="@*" mode="continued" />
                      <xsl:apply-templates select="current-group()[position() le $last]" mode="rs-continued" />


### PR DESCRIPTION
**Problem:** When processing continued elements, tag spans could extend too far if identical text content appeared multiple times (e.g. repeated words).

**Cause:** The code used index-of(current-group(), $final) to determine the position of a node within a group.
However, index-of() compares atomic values, not node identity.
As a result, multiple nodes with identical string values were treated as equal, and the last matching position was selected.

**Solution:** Replaced the index-of()-based lookup with a node identity comparison using "is", ensuring that the correct node instance is selected even when text content is identical.

**Result:** 
- Correct closing of tag spans
- No unintended merging across identical text nodes
- Stable behavior regardless of duplicate string values

This change avoids value-based comparison for node sequences and ensures consistent behavior when duplicate text nodes are present.

With many thanks!